### PR TITLE
2nd draft of new RasPi chapter, after incorporating feedback

### DIFF
--- a/xml/deployment_prep_aarch64.xml
+++ b/xml/deployment_prep_aarch64.xml
@@ -33,4 +33,5 @@
  <xi:include href="deployment_prep_aarch64_media.xml"/>
  <xi:include href="deployment_prep_aarch64_boot.xml"/>
  <xi:include href="aarch64_inst_problem.xml"/>
+ <xi:include href="deployment_prep_aarch64_raspi.xml" os="sles"/>
 </chapter>

--- a/xml/deployment_prep_aarch64_raspi.xml
+++ b/xml/deployment_prep_aarch64_raspi.xml
@@ -1,0 +1,261 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sect1
+[
+  <!ENTITY % entities SYSTEM "entity-decl.ent">
+    %entities;
+]>
+
+<sect1 version="5.0" xml:id="sec-aarch64-deprpi"
+ xmlns="http://docbook.org/ns/docbook"
+ xmlns:xi="http://www.w3.org/2001/XInclude"
+ xmlns:xlink="http://www.w3.org/1999/xlink">
+ <title>&rpi;</title>
+
+ <para>
+  &slsreg; is the first enterprise Linux distribution to support the inexpensive
+  &rpireg; single-board computer. &productname; &productnumber; supports the
+  following models:
+ </para>
+ <itemizedlist>
+  <listitem>
+   <para>
+    &rpi; 3 Model B
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    &rpi; 3 Model B+
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    &rpi; 3 Compute Module
+   </para>
+  </listitem>
+ </itemizedlist>
+
+ <para>
+  There are two different ways to deploy &sls; onto &rpi; hardware:
+ </para>
+ <itemizedlist>
+  <listitem>
+   <para>
+    Copy a pre-installed system image onto a MicroSD card.
+   </para>
+   <para>
+    This is the most common method for deploying operating systems on the
+    &rpi; platform.
+   </para>
+  </listitem>
+  <listitem>
+   <para>
+    Boot from USB media or the network, then install onto another drive.
+   </para>
+   <para>
+    This is the more conventional way to install &productname;, although it is less
+    common for &rpi; operating systems.
+   </para>
+  </listitem>
+ </itemizedlist>
+
+ <para>
+  There are several points to note regarding both methods.
+ </para>
+
+ <sect2>
+  <title>Deploying from a Pre-installed Image</title>
+  <para>
+   This method is the simplest and easiest method. However, it allows little
+   customisation of the product being deployed except for network and account
+   settings.
+  </para>
+  <para>
+   &suse; provides a pre-configured bootable image of &productname; for &rpi; 3
+   series
+   hardware. This comes with the lightweight IceWM desktop and the Btrfs file
+   system, with compression enabled to improve performance and reduce wear on
+   MicroSD media.
+  </para>
+  <para>
+   A MicroSD card with a minimum size of 8 GB is recommended. Faster cards will
+   give better system performance. On the first boot, the operating system
+   automatically expands the filesystem to fill the card. This means that the
+   first boot will be substantially slower than subsequent boots.
+  </para>
+  <para>
+   The process of writing the card image onto MicroSD media is described in the
+   Quick Start guide, here:
+   <link xlink:href="https://www.suse.com/documentation/sles-15/singlehtml/art-rpiquick/art-rpiquick.html#sec.rpi.installation"/>
+  </para>
+
+ </sect2>
+ <sect2>
+  <title>Installation from USB Media</title>
+  <para>
+   This method will be more familiar as it is the way &sls; is deployed
+   on other platforms. Installation can be performed from a removable USB
+   medium, such as a memory stick, onto a MicroSD card in the machine's internal
+   slot, or from a removable USB medium onto another USB medium, such as a
+   USB-connected hard disk.
+  </para>
+  <note>
+   <title>USB Bandwidth Limitations</title>
+   <para>
+    Note that the Ethernet, Wi-Fi and Bluetooth controllers on the &rpi; 3 are
+    all connected to the device's on-board USB 2 bus. Therefore an operating
+    system running from a disk attached via USB must share the total 480 Mbps
+    bandwidth of the USB controller. This will limit performance, and could
+    significantly impact network performance.
+   </para>
+  </note>
+  <para>
+   Installation on the &rpi; has some aspects that are unlike other
+   platforms.
+  </para>
+  <para>
+   The &rpi; differs from more conventional machines in two important ways:
+  </para>
+  <orderedlist>
+   <listitem>
+    <para>
+     The &rpi; hardware does not have any built-in firmware. Its firmware is
+     loaded from a special reserved FAT16 partition on the MicroSD card every
+     time that the machine is powered on. There is also no battery-backed clock
+     or non-volatile memory to hold configuration information.
+    </para>
+    <para>
+     This means there are no conventional settings to adjust for boot device
+     order, time and date, and so on.
+    </para>
+    <para>
+     Instead, the &rpi; has a very small amount of One-Time Programmable Memory
+     (OTP memory) which can be used to configure some settings, such as whether
+     the machine should attempt to boot from USB devices or over Ethernet. It is
+     only possible to program this by preparing a bootable MicroSD card and
+     placing certain configuration files on it.
+    </para>
+    <para>
+     This OTP memory is described on the &rpi; Foundation web site, here:
+     <link xlink:href="https://www.raspberrypi.org/documentation/hardware/raspberrypi/otpbits.mdd"/>
+    </para>
+    <note>
+     <title>Time Synchronization</title>
+     <para>
+      The lack of a Real Time Clock (RTC) also means that it is essential for
+      &rpi; devices to be configured to fetch the time from a network server by
+      &ntp;.
+    </para>
+    </note>
+   </listitem>
+   <listitem>
+    <para>
+     The primary processor on the &rpi; is the VideoCore IV Graphics Processing
+     Unit (GPU), not the &arm; processor. It is the GPU which initialises the
+     hardware and loads the operating system. As a result, most &rpi; operating
+     systems do not use a bootloader.
+    </para>
+    <para>
+     &sle; for the &rpi; is configured with a bootloader called
+     <literal>Das U-Boot</literal>, which is loaded before the operating system
+     and can optionally show a boot menu, like GRUB on &x86; hardware.
+    </para>
+   </listitem>
+  </orderedlist>
+
+  <para>
+   Installation can be performed from a bootable USB device, such as a memory
+   stick or USB optical drive. The exact procedure may differ from model to
+   model, depending on how the individual device is configured.
+  </para>
+  <para>
+   The &rpi; 3 Model B+ is shipped pre-configured to boot from USB devices and
+   no additional steps should be required.
+  </para>
+  <para>
+   Depending on whether this has previously been done on a particular unit, the
+   older &rpi; 3 Model B may require additional configuration to boot from USB.
+   The procedure is described on the &rpi; Foundation web site, here:
+   <link xlink:href="https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/msd.md"/>
+  </para>
+
+ </sect2>
+ <sect2>
+  <title>
+   Network Booting the &rpi;
+  </title>
+  <para>
+   Due to the hardware's lack of on-board firmware, network-booting the &rpi;
+   using PXE is more complex than with more conventional computers.
+  </para>
+  <para>
+   The process of setting up a PXE boot server for &x86; and &arm; is described
+   here:
+   <link xlink:href="https://www.suse.com/documentation/suse-best-practices/singlehtml/sbp-multi-pxe-install/sbp-multi-pxe-install.html"/>
+  </para>
+  <para>
+   The &rpi; Foundation publishes information on how to PXE boot one &rpi; from
+   another &rpi;, here:
+   <link xlink:href="https://www.raspberrypi.org/documentation/hardware/raspberrypi/bootmodes/net_tutorial.md"/>
+  </para>
+ </sect2>
+ <sect2>
+  <title>For More Information</title>
+  <para>
+   For more information, consult the following resources:
+  </para>
+  <variablelist>
+   <varlistentry>
+    <term>
+     &sls; 15 SP1 Release Notes
+    </term>
+    <listitem>
+     <para>
+      For more information about hardware compatibility, supported options and
+      functionality when running on &rpi; hardware, consult the relevant
+      section of the &sls; Release Notes:
+     </para>
+     <para>
+      <link xlink:href="https://www.suse.com/releasenotes/aarch64/SUSE-SLES/15-SP1/#fate-325731"/>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     &rpiquick;
+    </term>
+    <listitem>
+     <para>
+      <link xlink:href="https://www.suse.com/documentation/sles-15/singlehtml/art-rpiquick/art-rpiquick.html"/>
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     &opensuse; Hardware Compatibility List: &rpi; 3
+    </term>
+    <listitem>
+     <para>
+      The &opensuse; project also has information about installing and configuring
+      &rpi; hardware. Much of this also applies to &sle;.
+     </para>
+     <para>
+      See <link xlink:href="https://en.opensuse.org/HCL:Raspberry_Pi3"/>.
+     </para>
+    </listitem>
+   </varlistentry>
+   <varlistentry>
+    <term>
+     Das U-Boot
+    </term>
+    <listitem>
+     <para>
+      More information about <literal>Das U-Boot</literal> bootloader can
+      be found on the project's GitHub page at
+      <link xlink:href="https://github.com/u-boot/u-boot"/>.
+     </para>
+    </listitem>
+   </varlistentry>
+  </variablelist>
+ </sect2>
+
+</sect1>

--- a/xml/entity-decl.ent
+++ b/xml/entity-decl.ent
@@ -82,6 +82,7 @@
 <!ENTITY gnomeuser      "<citetitle xmlns='http://docbook.org/ns/docbook'>&gnome; User Guide</citetitle>">
 <!ENTITY instquick      "<citetitle xmlns='http://docbook.org/ns/docbook'>Installation Quick Start</citetitle>">
 <!ENTITY gnomequick     "<citetitle xmlns='http://docbook.org/ns/docbook'>&gnome; Quick Start</citetitle>">
+<!ENTITY rpiquick       "<citetitle xmlns='http://docbook.org/ns/docbook'>&rpi; Quick Start</citetitle>">
 <!ENTITY admin          "<citetitle xmlns='http://docbook.org/ns/docbook'>Administration Guide</citetitle>">
 <!ENTITY reference      "<citetitle xmlns='http://docbook.org/ns/docbook'>Reference</citetitle>">
 <!ENTITY startup        "<citetitle xmlns='http://docbook.org/ns/docbook'>Start-Up</citetitle>">
@@ -110,6 +111,7 @@
 <!ENTITY aarch64       "AArch64">
 <!ENTITY arm64         "&arm;&nbsp;&aarch64;">
 <!ENTITY rpi           "Raspberry&nbsp;Pi">
+<!ENTITY rpireg        "Raspberry&nbsp;Pi&reg;">
 
 <!-- ============================================================= -->
 <!--                    Technologies                               -->


### PR DESCRIPTION
RPi subsection under AArch64 (jsc#SLE-4393, jsc#SLE-4592, jsc#SLE-4262)

RPi section: entity fixes etc., profiling, other niceties

* Profile new RPi section for SLES only, assuming there is no openSUSE
  or SLED version of this

* Use entities throughout, in particular productname & productnumber

* Use standard section title "For More Information"

* Avoid 1-item lists

* Add entity for RPi Quick Start

Address cjshroder's comments: spell out "GPU", remove "BIOS" mention

Change XML ID for new chapter to "sec.aarch64.deprpi" to avoid potential clash with RPi article

### Description
A few sentences describing the overall goals of this pull request.
If there are relevant Bugzilla or FATE entries, reference them.

### Checklist
* Check all items that apply.

*Are backports required?*

- [ ] To maintenance/SLE15SP1
- [ ] To maintenance/SLE15SP0
- [ ] To maintenance/SLE12SP5
- [ ] To maintenance/SLE12SP4
- [ ] To maintenance/SLE12SP3
