### PR TITLE
Create workflow file for parallel DC files

### DIFF
--- a/.github/workflows/parallel.yml
+++ b/.github/workflows/parallel.yml
@@ -1,0 +1,96 @@
+---
+name: Validate Doc
+
+on:
+  push
+
+jobs:
+  dc-files:
+    runs-on: ubuntu-latest
+    outputs:
+      file: ${{ steps.set-dc-files.outputs.file }}
+      # generate output name file by using inner step output
+    steps:
+      - name: Output env variables
+        run: |
+          # Just for debugging purposes. Can be removed once it's stable
+          echo "PWD=$PWD"
+          echo "Default branch=${default-branch}"
+          echo "GITHUB_WORKFLOW=${GITHUB_WORKFLOW}"
+          echo "GITHUB_ACTION=$GITHUB_ACTION"
+          echo "GITHUB_ACTIONS=$GITHUB_ACTIONS"
+          echo "GITHUB_ACTOR=$GITHUB_ACTOR"
+          echo "GITHUB_REPOSITORY=$GITHUB_REPOSITORY"
+          echo "GITHUB_EVENT_NAME=$GITHUB_EVENT_NAME"
+          echo "GITHUB_EVENT_PATH=$GITHUB_EVENT_PATH"
+          echo "GITHUB_WORKSPACE=$GITHUB_WORKSPACE"
+          echo "GITHUB_SHA=$GITHUB_SHA"
+          echo "GITHUB_REF=$GITHUB_REF"
+          echo "GITHUB_HEAD_REF=$GITHUB_HEAD_REF"
+          echo "GITHUB_BASE_REF=$GITHUB_BASE_REF"
+
+      - name: Dump GitHub context
+        env:
+          GITHUB_CONTEXT: ${{ toJSON(github) }}
+        run: echo "$GITHUB_CONTEXT"
+      - name: Dump job context
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: echo "$JOB_CONTEXT"
+      - name: Dump steps context
+        env:
+          STEPS_CONTEXT: ${{ toJSON(steps) }}
+        run: echo "$STEPS_CONTEXT"
+      - name: Dump runner context
+        env:
+          RUNNER_CONTEXT: ${{ toJSON(runner) }}
+        run: echo "$RUNNER_CONTEXT"
+      - name: Dump strategy context
+        env:
+          STRATEGY_CONTEXT: ${{ toJSON(strategy) }}
+        run: echo "$STRATEGY_CONTEXT"
+      - name: Dump matrix context
+        env:
+          MATRIX_CONTEXT: ${{ toJSON(matrix) }}
+        run: echo "$MATRIX_CONTEXT"
+
+      - uses: actions/checkout@v2
+
+      - name: Create DC files
+        id: set-dc-files
+        # Give it an id to handle to get step outputs in the outputs key above
+        run: |
+          shopt -s extglob
+          DC=$(ls DC!(*-all|*-html) | jq -R -s -c 'split("\n")[:-1]')
+          echo "$DC"
+          echo "::set-output name=file::$DC"
+        # Define step output named file base on ls command transformed
+        # to JSON thanks to jq
+
+
+  validate:
+    runs-on: ubuntu-latest
+    needs: [dc-files]  # Depends on previous job
+    strategy:
+      matrix:
+        # List matrix strategy from directories dynamically
+        dc-file: ${{ fromJson(needs.dc-files.outputs.file) }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Pull Docker container
+        run: sudo docker pull susedoc/ci
+
+      - name: Create build directory
+        run: mkdir -p build/${{matrix.dc-file}}
+
+      - name: ${{matrix.dc-file}}
+        id: daps-validate
+        run: |
+          docker run -v $PWD:/home/ \
+            --env TERM=$TERM \
+            --workdir /home \
+            susedoc/ci \
+            daps -vv --builddir=build/${{matrix.dc-file}} \
+              -d ${{matrix.dc-file}} validate


### PR DESCRIPTION
### Description

This is an attempt to create a GitHub Action that:

* dynamically creates a list of DC files
* spin jobs for each DC file
* Validates the DC file through Docker & susedoc/ci.

Just a proof-of-concept of how to create dynamic jobs for DC files.
Thanks to Stefan for the hint! :green_heart:

Source: https://slashgear.github.io/how-to-split-test-by-folder-with-github-action/
